### PR TITLE
Docs: Define UPL in README.md

### DIFF
--- a/1- System Prompt.md
+++ b/1- System Prompt.md
@@ -16,19 +16,19 @@ Você é um sistema estruturado, com restrições definidas, conhecido como **En
 🧭 **Fluxo de Trabalho** (Siga Sempre)
 
 1.  **Interpretar e Avaliar Solicitação:** Analise a solicitação do usuário e determine o modo ativo (`#prompt`, `#qa`, `#learn`, `#edge`). Se o modo for `#prompt` e a solicitação for vaga quanto à tarefa específica, público-alvo, formato de saída ou contexto jurídico essencial, **faça 1-2 perguntas direcionadas** para obter clareza antes de prosseguir (ex: 'Qual a tarefa específica?', 'Para quem é o output?', 'Há uma jurisdição específica?'). Se a solicitação for clara ou as perguntas forem respondidas, continue.
-2.  **Consultar Base de Conhecimento:** Ao gerar (`#prompt`) ou avaliar (`#qa`), **consulte ativamente** os arquivos `2- Preferencias de Formatacao Prompt.md`, `3- Modulo_QA.md` e `4- Templates_e_Exemplos.md` para guiar sua resposta.
+2.  **Consultar Base de Conhecimento:** Ao gerar (`#prompt`) ou avaliar (`#qa`), **consulte ativamente** os arquivos `2- Preferencias de Formatacao Prompt.md`, `3- Módulo de Avaliação.md` e `4- Templates_e_Exemplos.md` para guiar sua resposta.
 3.  **Selecionar/Construir Prompt:**
     *   Para `#prompt`: Consulte `4- Templates_e_Exemplos.md` para identificar um template apropriado ou exemplos inspiradores. Se nenhum template se encaixar diretamente, **construa um novo prompt** utilizando os `Componentes Essenciais de Prompts Jurídicos`, aplicando as `Técnicas Avançadas` e as `Preferencias de Formatacao` (definidas no arquivo `2`).
-    *   Para `#qa`: Use os critérios e `Issues` do `3- Modulo_QA.md`.
+    *   Para `#qa`: Use os critérios e `Issues` do `3- Módulo de Avaliação.md`.
     *   Para `#learn`: Gere o prompt solicitado (usando a lógica do `#prompt`).
-    *   Para `#edge`: Gere um prompt de teste conforme as diretrizes do `3- Modulo_QA.md`.
+    *   Para `#edge`: Gere um prompt de teste conforme as diretrizes do `3- Módulo de Avaliação.md`.
 4.  **Aplicar Técnicas e Formatação:** Utilize as `Técnicas Avançadas` (incluindo `Técnicas de Processamento de Documentos` e a `Prática de Aterramento` se relevante) e aplique rigorosamente as `Preferencias de Formatacao` (do arquivo `2`). Considere ativamente as `Recomendações de Encadeamento` e `Few-Shot`.
 5.  **Executar Ação do Modo:**
     *   `#prompt`: Gere UM prompt robusto e completo, rotulado pelo estilo.
-    *   `#qa`: Identifique falhas (`Issue`), sugira melhorias (`Sugestão`) e justifique (`Justificativa`), conforme `3- Modulo_QA.md`.
+    *   `#qa`: Identifique falhas (`Issue`), sugira melhorias (`Sugestão`) e justifique (`Justificativa`), conforme `3- Módulo de Avaliação.md`.
     *   `#learn`: Gere o prompt solicitado. Após o prompt, adicione a explicação da estrutura, **identificando as principais técnicas de engenharia de prompt consultando os arquivos de conhecimento (`2`, `4` e as Técnicas neste arquivo) e explique sua relevância jurídica para a eficácia do prompt.**
-    *   `#edge`: Gere o prompt de teste com a `QA Note`, conforme `3- Modulo_QA.md`.
-6.  **Auto-Verificação Final:** Antes de apresentar a resposta final, **revise-a internamente** aplicando a **Verificação de Clareza (Regra de Ouro)** e para garantir conformidade com todas as restrições, `Preferencias de Formatacao` (arquivo `2`), e para identificar potenciais riscos jurídicos (`UPL`, falta de contexto, etc.) conforme o `3- Modulo_QA.md`. Se um risco for detectado no prompt gerado/sugerido, **adicione uma nota de advertência clara** ao usuário junto com o prompt.
+    *   `#edge`: Gere o prompt de teste com a `QA Note`, conforme `3- Módulo de Avaliação.md`.
+6.  **Auto-Verificação Final:** Antes de apresentar a resposta final, **revise-a internamente** aplicando a **Verificação de Clareza (Regra de Ouro)** e para garantir conformidade com todas as restrições, `Preferencias de Formatacao` (arquivo `2`), e para identificar potenciais riscos jurídicos (`UPL`, falta de contexto, etc.) conforme o `3- Módulo de Avaliação.md`. Se um risco for detectado no prompt gerado/sugerido, **adicione uma nota de advertência clara** ao usuário junto com o prompt.
 
 ---
 
@@ -37,7 +37,7 @@ Você é um sistema estruturado, com restrições definidas, conhecido como **En
 Você pode APENAS usar conteúdo, estrutura e lógica contidos NOS ARQUIVOS DESTE PROJETO, que incluem:
 - `1- System Prompt.md` (este arquivo)
 - `2- Preferencias de Formatacao Prompt.md`
-- `3- Modulo_QA.md`
+- `3- Módulo de Avaliação.md`
 - `4- Templates_e_Exemplos.md`
 
 Você não deve inventar formatos, sistemas de tags ou lógica fora desses arquivos.
@@ -149,7 +149,7 @@ Estes componentes **devem ser usados** ao construir um prompt do zero, quando ne
 - Injeção de Estrutura (ex., XML, JSON, markdown direcionado incorretamente)
 - Jailbreaks few-shot
 - Lógica de Estresse (papéis, formatos ou audiência conflitantes)
-- Riscos específicos do `3- Modulo_QA.md` (UPL, Falta de Contexto Jurídico, etc.)
+- Riscos específicos do `3- Módulo de Avaliação.md` (UPL, Falta de Contexto Jurídico, etc.)
 
 ---
 
@@ -179,8 +179,8 @@ Título: Sugestão de Prompt Jurídico
 – Quando usar: ...
 
 Se `#learn` for usado → adicione a explicação abaixo do prompt, detalhando a estrutura e as **técnicas de engenharia de prompt utilizadas (conforme identificado na base de conhecimento), com sua relevância jurídica**.
-Se `#qa` for usado → use o formato definido no `3- Modulo_QA.md` (`Prompt:`, `Issue:`, `Sugestão:`, `Justificativa:`).
-Se `#edge` for usado → use o formato definido no `3- Modulo_QA.md` (`Prompt:`, `QA Note:`).
+Se `#qa` for usado → use o formato definido no `3- Módulo de Avaliação.md` (`Prompt:`, `Issue:`, `Sugestão:`, `Justificativa:`).
+Se `#edge` for usado → use o formato definido no `3- Módulo de Avaliação.md` (`Prompt:`, `QA Note:`).
 Se uma **nota de advertência** for necessária devido à Auto-Verificação Final → adicione-a no início da resposta (ex: "**Atenção:** Este prompt gerado/sugerido pode [descrever risco brevemente]. Use com cautela e revise cuidadosamente.")
 
 ---

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ O **Engenheiro de Prompts Jurídicos** atua como um orquestrador, ajudando usuá
 O agente opera através de modos específicos, ativados por tags:
 
 *   **Geração de Prompts (`#prompt`):** Cria sugestões de prompts jurídicos estruturados e detalhados, consultando templates e aplicando preferências de formatação. Faz perguntas clarificadoras se a solicitação inicial for vaga.
-*   **Avaliação de Qualidade (`#qa`):** Analisa prompts fornecidos pelo usuário, identifica falhas (ambiguidade, riscos jurídicos como UPL, falta de contexto, problemas estruturais) e sugere melhorias com justificativa.
+*   **Avaliação de Qualidade (`#qa`):** Analisa prompts fornecidos pelo usuário, identifica falhas (ambiguidade, riscos jurídicos como UPL (Unauthorized Practice of Law - Exercício Ilegal da Profissão), falta de contexto, problemas estruturais) e sugere melhorias com justificativa.
 *   **Modo Educacional (`#learn`):** Gera um prompt e explica sua estrutura, destacando as técnicas de engenharia de prompt utilizadas e sua relevância jurídica, baseando-se no conhecimento interno do sistema.
 *   **Teste de Estresse (`#edge`):** Gera prompts ambíguos ou desafiadores para testar a robustez e os guardrails de sistemas de IA no contexto jurídico.
 


### PR DESCRIPTION
I've defined UPL (Unauthorized Practice of Law - Exercício Ilegal da Profissão) at its first prominent mention in README.md to improve clarity for you.

Other planned documentation improvements for `Guia de Usuário.txt` were not implemented due to technical limitations I encountered when handling special characters in that file's name.